### PR TITLE
Fix empty check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- `isNotEmpty()` should not throw for '0' strings.
+
 ## [1.1.0] - 2016-03-28
 ### Added
 - Numeric preconditions

--- a/src/Preconditions/EmptyPreconditions.php
+++ b/src/Preconditions/EmptyPreconditions.php
@@ -16,11 +16,11 @@ trait EmptyPreconditions
      */
     public function isNotEmpty()
     {
-        if (is_string($this->getSubject()) && empty(trim($this->getSubject()))) {
+        if (is_string($this->getSubject()) && trim($this->getSubject()) === '') {
             throw new EmptyString('Subject must not be an empty string when trimmed');
         }
 
-        if (empty($this->getSubject())) {
+        if (!is_string($this->getSubject()) && empty($this->getSubject())) {
             throw new EmptyValue('Subject must not be empty');
         }
 

--- a/tests/Preconditions/EmptyPreconditionsTest.php
+++ b/tests/Preconditions/EmptyPreconditionsTest.php
@@ -5,7 +5,6 @@ class EmptyPreconditionsTest extends \PHPUnit_Framework_TestCase
     public function emptyProvider()
     {
         return [
-            ['0'],
             [0],
             [0.0],
             [false],
@@ -45,6 +44,7 @@ class EmptyPreconditionsTest extends \PHPUnit_Framework_TestCase
         return [
             ['string'],
             ['123'],
+            ['0'],
             [1],
             [1.2],
             [7E-10],

--- a/tests/Preconditions/EmptyPreconditionsTest.php
+++ b/tests/Preconditions/EmptyPreconditionsTest.php
@@ -27,6 +27,7 @@ class EmptyPreconditionsTest extends \PHPUnit_Framework_TestCase
         return [
             [''],
             [' '],
+            ["\t\r\0\n"],
         ];
     }
 


### PR DESCRIPTION
`isNotEmpty` incorrectly throws `EmptyString` exception for a string of '0'